### PR TITLE
feat(LAD): added plugin information to LAD and events.xml

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,9 @@
   "requiredSdkVersion": "~0.0.84",
   "name": "VisualSubmit",
   "javascriptEntrypointUrl": "VisualSubmit.js",
+  "eventPersistence": {
+    "isEnabled": true
+  },
   "remoteDataSources": [
     {
       "name": "fileUpload",

--- a/src/components/visual-submit/component.tsx
+++ b/src/components/visual-submit/component.tsx
@@ -70,7 +70,7 @@ function PluginVisualSubmit({ pluginUuid }: PluginVisualSubmitProps): React.Reac
       const userSubmitCount: {[key: string]: number} = {};
       submittedImages.filter((submittedImage) => {
         if (
-          submittedImage.payloadJson.renderedInLAD
+          submittedImage.payloadJson.sentToLearningAnalyticsDashboard
         ) {
           const currentUserSubmitCount = userSubmitCount[
             submittedImage.payloadJson.submittedBy.userId]
@@ -79,7 +79,7 @@ function PluginVisualSubmit({ pluginUuid }: PluginVisualSubmitProps): React.Reac
             submittedImage.payloadJson.submittedBy.userId
           ] = currentUserSubmitCount + 1;
         }
-        return !submittedImage.payloadJson.renderedInLAD;
+        return !submittedImage.payloadJson.sentToLearningAnalyticsDashboard;
       }).forEach(
         (submittedImage) => {
           const submitNumber = userSubmitCount[submittedImage.payloadJson.submittedBy.userId]
@@ -87,7 +87,7 @@ function PluginVisualSubmit({ pluginUuid }: PluginVisualSubmitProps): React.Reac
           const submitColumnTitle = `Submit ${submitNumber + 1}`;
           pluginApi.sendGenericDataForLearningAnalyticsDashboard({
             columnTitle: submitColumnTitle,
-            value: `[Submit](${submittedImage.payloadJson.imageUrl})`,
+            value: `![Submit ${submitNumber + 1}](${submittedImage.payloadJson.imageUrl})`,
             cardTitle: 'Visual Submit',
           });
           pluginApi.persistEvent('Visual Submit', {
@@ -96,7 +96,7 @@ function PluginVisualSubmit({ pluginUuid }: PluginVisualSubmitProps): React.Reac
           });
           updateSubmitImage(submittedImage.entryId, {
             ...submittedImage.payloadJson,
-            renderedInLAD: true,
+            sentToLearningAnalyticsDashboard: true,
           });
         },
       );
@@ -144,7 +144,7 @@ function PluginVisualSubmit({ pluginUuid }: PluginVisualSubmitProps): React.Reac
           userId: currentUser.userId,
           userName: currentUser.name,
         },
-        renderedInLAD: false,
+        sentToLearningAnalyticsDashboard: false,
       };
 
       pushSubmitImage(submitData, {

--- a/src/components/visual-submit/types.ts
+++ b/src/components/visual-submit/types.ts
@@ -4,7 +4,7 @@ export interface SubmitImage {
     userId: string;
     userName: string;
   };
-  renderedInLAD: boolean;
+  sentToLearningAnalyticsDashboard: boolean;
 }
 
 export interface UserMetadata {

--- a/src/components/visual-submit/types.ts
+++ b/src/components/visual-submit/types.ts
@@ -3,7 +3,8 @@ export interface SubmitImage {
   submittedBy: {
     userId: string;
     userName: string;
-  }
+  };
+  renderedInLAD: boolean;
 }
 
 export interface UserMetadata {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "es5",
         "jsx": "react",
         "allowJs": true,
+        "skipLibCheck": true,
         "moduleResolution": "node"
     },
     "include": ["src/*"],


### PR DESCRIPTION
### What does this PR do?

It adds this plugin's information to the learning-dashboard and `events.xml`.

### Motivation

This will give the teacher more information on the student's struggle (post-meeting)

### More

Closely related to the PR on core adding support for markdown in the LAD:

https://github.com/bigbluebutton/bigbluebutton/pull/23566

In the `events.xml` the result is as follows:

```xml
  <event timestamp="30936233" module="PLUGIN" eventname="PluginGeneratedEvent">
    <payloadJson>{"imageUrl":"/api/plugin-assets/1753aa6557d6ff0cbda692a3baf4e6cde3993999-1752780966918/dce414ec-0c52.png","renderedInLAD":false,"submittedBy":{"userId":"w_v9ehyz40x8pp","userName":"Guilherme"}}</payloadJson>
    <userId>w_v9ehyz40x8pp</userId>
    <timestampUTC>1752780998777</timestampUTC>
    <pluginName>VisualSubmit</pluginName>
    <pluginEventName>Visual Submit</pluginEventName>
    <date>2025-07-17T19:36:38.777Z</date>
  </event>
```

Here are some screenshots on how it

<img width="1847" height="759" alt="image" src="https://github.com/user-attachments/assets/9e7fcd29-8be9-4704-a810-48416e6fbc0f" />

